### PR TITLE
Построение по сеткам известных точек + исправление багов

### DIFF
--- a/examples/Machine_learning/SVC/_2D/Example_SVC_2D_Transformators_State.py
+++ b/examples/Machine_learning/SVC/_2D/Example_SVC_2D_Transformators_State.py
@@ -1,13 +1,13 @@
 from iOpt.output_system.listeners.static_painters import StaticPainterNDListener
 from iOpt.output_system.listeners.animate_painters import AnimatePainterNDListener
 from iOpt.output_system.listeners.console_outputers import ConsoleOutputListener
+from iOpt.output_system.listeners.static_painters import StaticDiscreteListener
 
 from iOpt.solver import Solver
 from iOpt.solver_parametrs import SolverParameters
 from examples.Machine_learning.SVC._2D.Problems import SVC_2D_Transformators_State
 from sklearn.utils import shuffle
 import numpy as np
-import pandas as pd
 import csv
 
 def factory_dataset():
@@ -25,16 +25,37 @@ def factory_dataset():
 
 
 if __name__ == "__main__":
+    '''
     X, Y = factory_dataset()
     regularization_value_bound = {'low': 5, 'up': 9}
     kernel_coefficient_bound = {'low': -3, 'up': 1}
-    problem = SVC_2D_Transformators_State.SVC_2D_Transformators_State(X, Y, regularization_value_bound, kernel_coefficient_bound)
+    problem = SVC_2D_Transformators_State.SVC_2D_Transformators_State(X, Y, regularization_value_bound,
+                                                                      kernel_coefficient_bound)
+    method_params = SolverParameters(r=np.double(2.0), iters_limit=2000, number_of_parallel_points=5,
+                                     evolvent_density=12)
+    solver = Solver(problem=problem, parameters=method_params)
+    spl = StaticPainterNDListener("svc2d_transformator_state_stat.png", "output", vars_indxs=[0, 1], mode="surface",
+                                  calc="by points")
+    solver.add_listener(spl)
+    log = "SVC_2D_Transformators_2000"
+    solver.load_progress(log)                 # загружаем точки из файла в солвер
+    solver.release_all_listener()             # запускаем подключенных слушаетей
+    '''
+
+    X, Y = factory_dataset()
+    regularization_value_bound = {'low': 5, 'up': 9}
+    kernel_coefficient_bound = {'low': -3, 'up': 1}
+    problem = SVC_2D_Transformators_State.SVC_2D_Transformators_State(X, Y, regularization_value_bound,
+                                                                      kernel_coefficient_bound)
     method_params = SolverParameters(r=np.double(2.0), iters_limit=100)
     solver = Solver(problem, parameters=method_params)
-    #apl = AnimatePainterNDListener("svc2d_transformator_state_anim.png", "output", vars_indxs=[0, 1])
-    #solver.add_listener(apl)
-    #spl = StaticPainterNDListener("svc2d_transformator_state_stat.png", "output", vars_indxs=[0, 1], mode="surface", calc="interpolation")
-    #solver.add_listener(spl)
+    spl = StaticPainterNDListener("svc2d_transformator_state_stat.png", "output", vars_indxs=[0, 1],
+                                  mode="surface", calc="by points")
+    solver.add_listener(spl)
+    spl2 = StaticPainterNDListener("svc2d_transformator_state_stat.png", "output", vars_indxs=[0, 1],
+                                  mode="surface", calc="interpolation")
+    solver.add_listener(spl2)
     cfol = ConsoleOutputListener(mode='full')
     solver.add_listener(cfol)
     solver_info = solver.solve()
+

--- a/examples/Machine_learning/SVC/_2D/Example_SVC_2D_Transformators_State.py
+++ b/examples/Machine_learning/SVC/_2D/Example_SVC_2D_Transformators_State.py
@@ -33,9 +33,12 @@ if __name__ == "__main__":
     method_params = SolverParameters(r=np.double(2.0), iters_limit=2000, number_of_parallel_points=5,
                                      evolvent_density=12)
     solver = Solver(problem=problem, parameters=method_params)
-    spl = StaticPainterNDListener("svc2d_transformator_state_stat.png", "output", vars_indxs=[0, 1], mode="surface",
+    spl1 = StaticPainterNDListener("svc2d_transformator_state_stat1.png", "output", vars_indxs=[0, 1], mode="surface",
                                   calc="by points")
-    solver.add_listener(spl)
+    solver.add_listener(spl1)
+    spl2 = StaticPainterNDListener("svc2d_transformator_state_stat2.png", "output", vars_indxs=[0, 1], mode="lines layers",
+                                  calc="by points")
+    solver.add_listener(spl2)
     log = "SVC_2D_Transformators_2000"
     solver.load_progress(log)                 # загружаем точки из файла в солвер
     solver.release_all_listener()             # запускаем подключенных слушаетей

--- a/examples/Machine_learning/SVC/_2D/Example_SVC_2D_Transformators_State.py
+++ b/examples/Machine_learning/SVC/_2D/Example_SVC_2D_Transformators_State.py
@@ -25,7 +25,6 @@ def factory_dataset():
 
 
 if __name__ == "__main__":
-    '''
     X, Y = factory_dataset()
     regularization_value_bound = {'low': 5, 'up': 9}
     kernel_coefficient_bound = {'low': -3, 'up': 1}
@@ -40,8 +39,8 @@ if __name__ == "__main__":
     log = "SVC_2D_Transformators_2000"
     solver.load_progress(log)                 # загружаем точки из файла в солвер
     solver.release_all_listener()             # запускаем подключенных слушаетей
-    '''
 
+    '''
     X, Y = factory_dataset()
     regularization_value_bound = {'low': 5, 'up': 9}
     kernel_coefficient_bound = {'low': -3, 'up': 1}
@@ -58,4 +57,4 @@ if __name__ == "__main__":
     cfol = ConsoleOutputListener(mode='full')
     solver.add_listener(cfol)
     solver_info = solver.solve()
-
+    '''

--- a/iOpt/output_system/listeners/static_painters.py
+++ b/iOpt/output_system/listeners/static_painters.py
@@ -138,7 +138,7 @@ class StaticPainterNDListener(Listener):
            The 'lines layers' mode draws level lines in the cross-section of the solution found by the method.
            The 'surface' mode draws the surface in the cross-section of the solution found by the method.
         :param calc: The calculation method for drawing the graph of the objective function that will be used. Possible
-           modes: 'objective function' (only in the 'line layers' mode), 'approximation' (only in the 'surface' mode)
+           modes: 'objective function' (only in the 'line layers' mode), 'approximation' (only in the 'surface' mode), 'by points'
            and 'interpolation'. The 'objective function' mode builds a graph by calculating the values of the objective function on a uniform grid.
            grid. The 'approximation' mode builds a neuroapproximation for the objective function based on the obtained search information.
            information. The 'interpolation' mode builds interpolation for the objective function based on the obtained search information.

--- a/iOpt/output_system/painters/plotters/plotters.py
+++ b/iOpt/output_system/painters/plotters/plotters.py
@@ -211,7 +211,8 @@ class DisretePlotter:
                 x1, x2 = np.meshgrid(x1, x2)
                 z = interp(x1, x2)
                 xx=self.axes[0].contour(x1, x2, z, levels=10, linewidths=1, cmap='plasma')
-                self.fig.colorbar(ScalarMappable(norm=xx.norm, cmap=xx.cmap))
+                #self.fig.colorbar(xx, ax = self.axes[0], ticks=xx.levels)
+                self.fig.colorbar(ScalarMappable(norm=xx.norm, cmap=xx.cmap), ax=self.axes[0], orientation='vertical')
             else:
                 f = interpolate.interp1d(np.array(points), np.array(values), kind=3)
                 x_plot = np.linspace(min(np.array(points)), max(np.array(points)), points_count)
@@ -274,7 +275,7 @@ class Plotter2D(Plotter):
         self.ax.scatter(points, values, color=clr, marker=mrkr, s=mrkrs)
 
 class Plotter3D(Plotter):
-    def __init__(self, parameters_in_nd_problem, left_bounds, right_bounds, obj_func, plotter_type):
+    def __init__(self, parameters_in_nd_problem, left_bounds, right_bounds, obj_func, plotter_type, calc_type):
         plt.style.use('fivethirtyeight')
         plt.rcParams['contour.negative_linestyle'] = 'solid'
         plt.rcParams["figure.figsize"] = (8, 6)
@@ -283,6 +284,7 @@ class Plotter3D(Plotter):
         self.leftBounds = left_bounds
         self.rightBounds = right_bounds
         self.objFunc = obj_func
+        self.calc_type = calc_type
 
         self.plotterType = plotter_type
 
@@ -352,11 +354,18 @@ class Plotter3D(Plotter):
             z = interp(x1, x2)
             self.ax.plot_surface(x1, x2, z, cmap=plt.cm.viridis, alpha=0.6)
 
+    def plot_by_points(self, points, values):
+        if self.plotterType == 'surface':
+            surf = self.ax.plot_trisurf(np.array(points)[:, 0], np.array(points)[:, 1], values, cmap=plt.cm.viridis, alpha=0.95)
     def plot_points(self, points, values, clr='blue', mrkr='o', mrkrs=3):
         if self.plotterType == 'lines layers':
             self.ax.scatter(np.array(points)[:, 0], np.array(points)[:, 1], color=clr, marker=mrkr, s=mrkrs)
         elif self.plotterType == 'surface':
-            self.ax.scatter(np.array(points)[:, 0], np.array(points)[:, 1], values, s=mrkrs, color=clr, marker=mrkr, alpha=1.0)
+            if self.calc_type == 'by points':
+                self.ax.scatter(np.array(points)[:, 0], np.array(points)[:, 1], values, s=mrkrs, color=clr, marker=mrkr,
+                                alpha=0.2)
+            else:
+                self.ax.scatter(np.array(points)[:, 0], np.array(points)[:, 1], values, s=mrkrs, color=clr, marker=mrkr, alpha=1.0)
 
 class AnimatePlotter2D(Plotter2D):
     def __init__(self, parameters_in_nd_problem, left_bounds, right_bounds, obj_func=None,

--- a/iOpt/output_system/painters/plotters/plotters.py
+++ b/iOpt/output_system/painters/plotters/plotters.py
@@ -357,6 +357,8 @@ class Plotter3D(Plotter):
     def plot_by_points(self, points, values):
         if self.plotterType == 'surface':
             self.ax.plot_trisurf(np.array(points)[:, 0], np.array(points)[:, 1], values, cmap=plt.cm.viridis, alpha=0.95)
+        if self.plotterType == 'lines layers':
+            self.ax.tricontourf(np.array(points)[:, 0], np.array(points)[:, 1], values, cmap=plt.cm.viridis)
     def plot_points(self, points, values, clr='blue', mrkr='o', mrkrs=3):
         if self.plotterType == 'lines layers':
             self.ax.scatter(np.array(points)[:, 0], np.array(points)[:, 1], color=clr, marker=mrkr, s=mrkrs)

--- a/iOpt/output_system/painters/plotters/plotters.py
+++ b/iOpt/output_system/painters/plotters/plotters.py
@@ -26,7 +26,7 @@ class DisretePlotter:
         self.combcount = len(self.discreteParamsCombinations)
 
         if mode == 'analysis':
-            self.fig, self.ax = plt.subplots(figsize=(8, 6))
+            self.fig = plt.Figure()
             self.fig.suptitle('Analysis optimization method work', fontsize=10)
             self.axes = []
 
@@ -64,7 +64,7 @@ class DisretePlotter:
             self.axes[self.count + 3].set_yticks([])
 
         elif mode == 'bestcombination':
-            self.fig, self.ax = plt.subplots(figsize=(8, 6))
+            self.fig = plt.Figure()
             self.axes = []
             self.axes.append(plt.subplot2grid((9, 1), (0, 0), colspan=1, rowspan=8))
             self.axes.append(plt.subplot2grid((9, 1), (8, 0), colspan=1, rowspan=1))
@@ -288,7 +288,7 @@ class Plotter3D(Plotter):
 
         self.plotterType = plotter_type
 
-        self.fig = plt.subplot()
+        self.fig = plt.Figure()
         if self.plotterType == 'surface':
             self.ax = plt.subplot(projection='3d')
         elif self.plotterType == 'lines layers':
@@ -356,7 +356,7 @@ class Plotter3D(Plotter):
 
     def plot_by_points(self, points, values):
         if self.plotterType == 'surface':
-            surf = self.ax.plot_trisurf(np.array(points)[:, 0], np.array(points)[:, 1], values, cmap=plt.cm.viridis, alpha=0.95)
+            self.ax.plot_trisurf(np.array(points)[:, 0], np.array(points)[:, 1], values, cmap=plt.cm.viridis, alpha=0.95)
     def plot_points(self, points, values, clr='blue', mrkr='o', mrkrs=3):
         if self.plotterType == 'lines layers':
             self.ax.scatter(np.array(points)[:, 0], np.array(points)[:, 1], color=clr, marker=mrkr, s=mrkrs)

--- a/iOpt/output_system/painters/static_painters.py
+++ b/iOpt/output_system/painters/static_painters.py
@@ -231,7 +231,8 @@ class StaticPainterND(Painter):
                             float(solution.problem.upper_bound_of_float_variables[parameters[1]])]
 
         # настройки графика
-        self.plotter = Plotter3D(parameters, self.leftBounds, self.rightBounds, solution.problem.calculate, self.objectFunctionPainterType)
+        self.plotter = Plotter3D(parameters, self.leftBounds, self.rightBounds, solution.problem.calculate,
+                                 self.objectFunctionPainterType, self.objectFunctionCalculatorType)
 
     def paint_objective_func(self):
         if self.objectFunctionPainterType == 'lines layers':
@@ -239,6 +240,8 @@ class StaticPainterND(Painter):
                 self.plotter.plot_by_grid(self.calculate_func, self.optimum, points_count=100)
             elif self.objectFunctionCalculatorType == 'interpolation':
                 self.plotter.plot_interpolation(self.points, self.values, points_count=100)
+            elif self.objectFunctionCalculatorType == 'by points':
+               self.plotter.plot_by_points(self.points, self.values)
             elif self.objectFunctionCalculatorType == "approximation":
                 pass
         elif self.objectFunctionPainterType == 'surface':
@@ -246,6 +249,8 @@ class StaticPainterND(Painter):
                 self.plotter.plot_approximation(self.points, self.values, points_count=50)
             elif self.objectFunctionCalculatorType == 'interpolation':
                 self.plotter.plot_interpolation(self.points, self.values, points_count=50)
+            elif self.objectFunctionCalculatorType == 'by points':
+               self.plotter.plot_by_points(self.points, self.values)
             elif self.objectFunctionCalculatorType == "objective function":
                 pass
 


### PR DESCRIPTION
Добавлен режим отрисовки по загруженным точкам
```
spl1 = StaticPainterNDListener("svc2d_transformator_state_stat1.png", "output", vars_indxs=[0, 1], mode="surface", calc="by points")
spl2 = StaticPainterNDListener("svc2d_transformator_state_stat2.png", "output", vars_indxs=[0, 1], mode="lines layers", calc="by points")
```
![Figure_1](https://github.com/aimclub/iOpt/assets/22386453/1c63c79b-4733-4b9f-87db-ce601f97e248)
![Figure_3](https://github.com/aimclub/iOpt/assets/22386453/d463e836-61ce-4d3d-a19e-2e7bd9d92559)

а также исправлены баги:
- отрисовка двойной сетки (за графиком начала отображаться сетка фигуры и их получалось две) после обновления matplotlib
- ошибка с colorbar после обновления matplotlib